### PR TITLE
Make Detekt not fail build by default

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,4 +28,4 @@ jobs:
       with:
         java-version: 1.11
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build -PfailOnDetekt=true

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ detekt {
     toolVersion = "1.1.1"
     input = files("src/main/kotlin")
     config = files("config/detekt/detekt.yml")
+    ignoreFailures = project.hasProperty("failOnDetekt") ? !project.findProperty("failOnDetekt") : true
 }
 
 repositories {

--- a/src/main/kotlin/com/team4099/robot2020/subsystems/Drive.kt
+++ b/src/main/kotlin/com/team4099/robot2020/subsystems/Drive.kt
@@ -20,6 +20,10 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard
 import edu.wpi.first.wpilibj.trajectory.Trajectory
 import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig
 import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator
+import edu.wpi.first.wpilibj.trajectory.*
+import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile
+import edu.wpi.first.wpilibj.trajectory.TrajectoryUtil
+import edu.wpi.first.wpilibj.trajectory.TrajectoryParameterizer
 import kotlin.math.abs
 import kotlin.math.ln
 import kotlin.math.max

--- a/src/main/kotlin/com/team4099/robot2020/subsystems/Drive.kt
+++ b/src/main/kotlin/com/team4099/robot2020/subsystems/Drive.kt
@@ -18,12 +18,6 @@ import edu.wpi.first.wpilibj.kinematics.DifferentialDriveOdometry
 import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard
 import edu.wpi.first.wpilibj.trajectory.Trajectory
-import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig
-import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator
-import edu.wpi.first.wpilibj.trajectory.*
-import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile
-import edu.wpi.first.wpilibj.trajectory.TrajectoryUtil
-import edu.wpi.first.wpilibj.trajectory.TrajectoryParameterizer
 import kotlin.math.abs
 import kotlin.math.ln
 import kotlin.math.max
@@ -33,7 +27,6 @@ import com.team4099.lib.drive.DriveSignal
 import com.team4099.lib.motorcontroller.CTREMotorControllerFactory
 import com.team4099.lib.subsystem.Subsystem
 import com.team4099.robot2020.config.Constants
-import edu.wpi.first.wpilibj.geometry.Pose2d
 
 object Drive : Subsystem {
     private val rightMasterTalon: TalonSRX

--- a/src/main/kotlin/com/team4099/robot2020/subsystems/SampleWrist.kt
+++ b/src/main/kotlin/com/team4099/robot2020/subsystems/SampleWrist.kt
@@ -1,7 +1,5 @@
 package com.team4099.robot2020.subsystems
 
-import com.ctre.phoenix.motorcontrol.can.BaseMotorController
-import com.ctre.phoenix.motorcontrol.can.TalonSRX
 import com.team4099.lib.motorcontroller.CTREMotorControllerFactory
 import com.team4099.lib.subsystem.ServoMotorSubsystem
 import com.team4099.robot2020.config.Constants


### PR DESCRIPTION
Added command line property to allow Detekt to be run -- defaults to not failing build because of Detekt errors. Github Actions still fails the build, though.